### PR TITLE
fix: make logger optional

### DIFF
--- a/protoconfloader.go
+++ b/protoconfloader.go
@@ -52,11 +52,17 @@ func WithAgentStub(stub pc.ProtoconfServiceClient) Option {
 	}
 }
 
+func WithLogger(logger *slog.Logger) Option {
+	return func(c *Configuration) {
+		c.logger = logger
+	}
+}
+
 // NewConfiguration creates a new Configuration instance with the given proto.Message,
-// service name, logger, and optional options.
+// service name and optional options.
 // It initializes the fsnotify watcher, sets the unmarshal options, and initializes other fields.
 // If any error occurs during the watcher creation, it returns an error.
-func NewConfiguration(p proto.Message, serviceName string, logger *slog.Logger, opts ...Option) (*Configuration, error) {
+func NewConfiguration(p proto.Message, serviceName string, opts ...Option) (*Configuration, error) {
 	fsnotifyWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
@@ -65,7 +71,7 @@ func NewConfiguration(p proto.Message, serviceName string, logger *slog.Logger, 
 	config := &Configuration{
 		msg:             p,
 		serviceName:     serviceName,
-		logger:          logger,
+		logger:          slog.Default(),
 		isLoaded:        &atomic.Bool{},
 		isWatchingFile:  &atomic.Bool{},
 		isWatchingAgent: &atomic.Bool{},

--- a/protoconfloader_test.go
+++ b/protoconfloader_test.go
@@ -91,7 +91,7 @@ func Test_LoadConfig(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			c, _ := NewConfiguration(&config, tt.args.serviceName, slog.New(handler))
+			c, _ := NewConfiguration(&config, tt.args.serviceName, WithLogger(slog.New(handler)))
 			if err := c.LoadConfig(tt.args.configPath, tt.args.configName); (err != nil) != tt.wantErr {
 				t.Errorf("LoadConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -113,7 +113,7 @@ func TestConfigFileChanges(t *testing.T) {
 	c := &pb.CrawlerService{}
 	handler := slog.NewJSONHandler(io.Discard, nil)
 	logger := slog.New(handler)
-	config, _ := NewConfiguration(c, "test_config.json", logger, WithAgentStub(mock.Stub))
+	config, _ := NewConfiguration(c, "test_config.json", WithLogger(logger), WithAgentStub(mock.Stub))
 
 	// Load the config
 	err := os.WriteFile(filepath.Join(testDir, "config.json"), []byte("{\"logLevel\":12}"), 0644)
@@ -151,7 +151,7 @@ func TestConfigFileChangesWithAgent(t *testing.T) {
 	c := &pb.CrawlerService{}
 	agent := newProtoconfAgentMock(&pb.CrawlerService{LogLevel: 21})
 	handler := slog.NewJSONHandler(io.Discard, nil)
-	config, err := NewConfiguration(c, "test_config.json", slog.New(handler), WithAgentStub(agent.Stub))
+	config, err := NewConfiguration(c, "test_config.json", WithLogger(slog.New(handler)), WithAgentStub(agent.Stub))
 	assert.NoError(t, err)
 	require.NotNil(t, config)
 


### PR DESCRIPTION
The library will use `slog.Default()` is logger is not set.